### PR TITLE
Unvalidated umarshalling/unmarshalling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,15 +8,11 @@ GOPKG := github.com/veraison/psatoken
 GOLINT ?= golangci-lint
 
 ifeq ($(MAKECMDGOALS),lint)
-GOLINT_ARGS ?= run --timeout=3m
-else
-  ifeq ($(MAKECMDGOALS),lint-extra)
-  GOLINT_ARGS ?= run --timeout=3m --issues-exit-code=0 -E dupl -E gocritic -E gosimple -E lll -E prealloc
-  endif
+GOLINT_ARGS ?= run --timeout=3m -E dupl -E gocritic -E gosimple -E lll -E prealloc
 endif
 
-.PHONY: lint lint-extra
-lint lint-extra: ; $(GOLINT) $(GOLINT_ARGS)
+.PHONY: lint
+lint: ; $(GOLINT) $(GOLINT_ARGS)
 
 ifeq ($(MAKECMDGOALS),test)
 GOTEST_ARGS ?= -v -race $(GOPKG)
@@ -51,6 +47,5 @@ help:
 	@echo "  * test-cover: run unit tests and measure coverage for $(GOPKG)"
 	@echo "  * licenses:   check licenses of dependent packages"
 	@echo "  * lint:       lint sources using default configuration"
-	@echo "  * lint-extra: lint sources using default configuration and some extra checkers"
 	@echo "  * presubmit:  check you are ready to push your local branch to remote"
 	@echo "  * help:       print this menu"

--- a/claims_cca.go
+++ b/claims_cca.go
@@ -55,14 +55,23 @@ func (c CcaPlatformClaims) Validate() error {
 // Codecs
 
 func (c *CcaPlatformClaims) FromCBOR(buf []byte) error {
-	err := dm.Unmarshal(buf, c)
+	err := c.FromUnvalidatedCBOR(buf)
 	if err != nil {
-		return fmt.Errorf("CBOR decoding of CCA platform claims failed: %w", err)
+		return err
 	}
 
 	err = c.Validate()
 	if err != nil {
 		return fmt.Errorf("validation of CCA platform claims failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *CcaPlatformClaims) FromUnvalidatedCBOR(buf []byte) error {
+	err := dm.Unmarshal(buf, c)
+	if err != nil {
+		return fmt.Errorf("CBOR decoding of CCA platform claims failed: %w", err)
 	}
 
 	return nil
@@ -74,6 +83,10 @@ func (c CcaPlatformClaims) ToCBOR() ([]byte, error) {
 		return nil, fmt.Errorf("validation of CCA platform claims failed: %w", err)
 	}
 
+	return c.ToUnvalidatedCBOR()
+}
+
+func (c CcaPlatformClaims) ToUnvalidatedCBOR() ([]byte, error) {
 	buf, err := em.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("CBOR encoding of CCA platform claims failed: %w", err)
@@ -83,14 +96,23 @@ func (c CcaPlatformClaims) ToCBOR() ([]byte, error) {
 }
 
 func (c *CcaPlatformClaims) FromJSON(buf []byte) error {
-	err := json.Unmarshal(buf, c)
+	err := c.FromUnvalidatedJSON(buf)
 	if err != nil {
-		return fmt.Errorf("JSON decoding of CCA platform claims failed: %w", err)
+		return err
 	}
 
 	err = c.Validate()
 	if err != nil {
 		return fmt.Errorf("validation of CCA platform claims failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *CcaPlatformClaims) FromUnvalidatedJSON(buf []byte) error {
+	err := json.Unmarshal(buf, c)
+	if err != nil {
+		return fmt.Errorf("JSON decoding of CCA platform claims failed: %w", err)
 	}
 
 	return nil
@@ -102,6 +124,10 @@ func (c CcaPlatformClaims) ToJSON() ([]byte, error) {
 		return nil, fmt.Errorf("validation of CCA platform claims failed: %w", err)
 	}
 
+	return c.ToUnvalidatedJSON()
+}
+
+func (c CcaPlatformClaims) ToUnvalidatedJSON() ([]byte, error) {
 	buf, err := json.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("JSON encoding of CCA platform claims failed: %w", err)

--- a/claims_common.go
+++ b/claims_common.go
@@ -240,8 +240,8 @@ func isValidSecurityLifeCycle(v uint16, profile string) error {
 }
 
 var (
-	CertificationReferenceP1RE = regexp.MustCompile(`^[0-9]{13}$`)
-	CertificationReferenceP2RE = regexp.MustCompile(`^[0-9]{13}-[0-9]{5}$`)
+	CertificationReferenceP1RE = regexp.MustCompile(`^\d{13}$`)
+	CertificationReferenceP2RE = regexp.MustCompile(`^\d{13}-\d{5}$`)
 )
 
 func isValidImplID(v []byte) error {

--- a/claims_p1.go
+++ b/claims_p1.go
@@ -127,14 +127,23 @@ func (c *P1Claims) SetHashAlgID(v string) error {
 // Codecs
 
 func (c *P1Claims) FromCBOR(buf []byte) error {
-	err := dm.Unmarshal(buf, c)
+	err := c.FromUnvalidatedCBOR(buf)
 	if err != nil {
-		return fmt.Errorf("CBOR decoding of PSA claims failed: %w", err)
+		return err
 	}
 
 	err = c.Validate()
 	if err != nil {
 		return fmt.Errorf("validation of PSA claims failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *P1Claims) FromUnvalidatedCBOR(buf []byte) error {
+	err := dm.Unmarshal(buf, c)
+	if err != nil {
+		return fmt.Errorf("CBOR decoding of PSA claims failed: %w", err)
 	}
 
 	return nil
@@ -146,6 +155,10 @@ func (c P1Claims) ToCBOR() ([]byte, error) {
 		return nil, fmt.Errorf("validation of PSA claims failed: %w", err)
 	}
 
+	return c.ToUnvalidatedCBOR()
+}
+
+func (c P1Claims) ToUnvalidatedCBOR() ([]byte, error) {
 	buf, err := em.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("CBOR encoding of PSA claims failed: %w", err)
@@ -155,14 +168,23 @@ func (c P1Claims) ToCBOR() ([]byte, error) {
 }
 
 func (c *P1Claims) FromJSON(buf []byte) error {
-	err := json.Unmarshal(buf, c)
+	err := c.FromUnvalidatedJSON(buf)
 	if err != nil {
-		return fmt.Errorf("JSON decoding of PSA claims failed: %w", err)
+		return err
 	}
 
 	err = c.Validate()
 	if err != nil {
 		return fmt.Errorf("validation of PSA claims failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *P1Claims) FromUnvalidatedJSON(buf []byte) error {
+	err := json.Unmarshal(buf, c)
+	if err != nil {
+		return fmt.Errorf("JSON decoding of PSA claims failed: %w", err)
 	}
 
 	return nil
@@ -174,6 +196,10 @@ func (c P1Claims) ToJSON() ([]byte, error) {
 		return nil, fmt.Errorf("validation of PSA claims failed: %w", err)
 	}
 
+	return c.ToUnvalidatedJSON()
+}
+
+func (c P1Claims) ToUnvalidatedJSON() ([]byte, error) {
 	buf, err := json.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("JSON encoding of PSA claims failed: %w", err)

--- a/claims_p1.go
+++ b/claims_p1.go
@@ -37,7 +37,7 @@ func newP1Claims(includeProfile bool) (IClaims, error) {
 }
 
 // Semantic validation
-func (c P1Claims) Validate() error {
+func (c P1Claims) Validate() error { //nolint:gocritic
 	return validate(&c, PsaProfile1)
 }
 
@@ -149,7 +149,7 @@ func (c *P1Claims) FromUnvalidatedCBOR(buf []byte) error {
 	return nil
 }
 
-func (c P1Claims) ToCBOR() ([]byte, error) {
+func (c P1Claims) ToCBOR() ([]byte, error) { //nolint:gocritic
 	err := c.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("validation of PSA claims failed: %w", err)
@@ -158,7 +158,7 @@ func (c P1Claims) ToCBOR() ([]byte, error) {
 	return c.ToUnvalidatedCBOR()
 }
 
-func (c P1Claims) ToUnvalidatedCBOR() ([]byte, error) {
+func (c P1Claims) ToUnvalidatedCBOR() ([]byte, error) { //nolint:gocritic
 	buf, err := em.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("CBOR encoding of PSA claims failed: %w", err)
@@ -190,7 +190,7 @@ func (c *P1Claims) FromUnvalidatedJSON(buf []byte) error {
 	return nil
 }
 
-func (c P1Claims) ToJSON() ([]byte, error) {
+func (c P1Claims) ToJSON() ([]byte, error) { //nolint:gocritic
 	err := c.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("validation of PSA claims failed: %w", err)
@@ -199,7 +199,7 @@ func (c P1Claims) ToJSON() ([]byte, error) {
 	return c.ToUnvalidatedJSON()
 }
 
-func (c P1Claims) ToUnvalidatedJSON() ([]byte, error) {
+func (c P1Claims) ToUnvalidatedJSON() ([]byte, error) { //nolint:gocritic
 	buf, err := json.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("JSON encoding of PSA claims failed: %w", err)
@@ -213,7 +213,7 @@ func (c P1Claims) ToUnvalidatedJSON() ([]byte, error) {
 // to never fail.  Getters of optional claim may still fail with
 // ErrOptionalClaimMissing in case the claim is not present.
 
-func (c P1Claims) GetProfile() (string, error) {
+func (c P1Claims) GetProfile() (string, error) { //nolint:gocritic
 	if c.Profile == nil {
 		return PsaProfile1, nil
 	}
@@ -221,28 +221,28 @@ func (c P1Claims) GetProfile() (string, error) {
 	return *c.Profile, nil
 }
 
-func (c P1Claims) GetClientID() (int32, error) {
+func (c P1Claims) GetClientID() (int32, error) { //nolint:gocritic
 	return getClientID(c.ClientID)
 }
 
-func (c P1Claims) GetSecurityLifeCycle() (uint16, error) {
+func (c P1Claims) GetSecurityLifeCycle() (uint16, error) { //nolint:gocritic
 	return getSecurityLifeCycle(c.SecurityLifeCycle, PsaProfile1)
 }
 
-func (c P1Claims) GetImplID() ([]byte, error) {
+func (c P1Claims) GetImplID() ([]byte, error) { //nolint:gocritic
 	return getImplID(c.ImplID)
 }
 
-func (c P1Claims) GetBootSeed() ([]byte, error) {
+func (c P1Claims) GetBootSeed() ([]byte, error) { //nolint:gocritic
 	return getBootSeed(c.BootSeed, PsaProfile1)
 }
 
-func (c P1Claims) GetCertificationReference() (string, error) {
+func (c P1Claims) GetCertificationReference() (string, error) { //nolint:gocritic
 	return getCertificationReference(c.CertificationReference, PsaProfile1)
 }
 
 // Caveat: this may return nil on success if psa-no-sw-measurement is asserted
-func (c P1Claims) GetSoftwareComponents() ([]SwComponent, error) {
+func (c P1Claims) GetSoftwareComponents() ([]SwComponent, error) { //nolint:gocritic
 	v := c.SwComponents
 	f := c.NoSwMeasurements
 
@@ -270,7 +270,7 @@ func (c P1Claims) GetSoftwareComponents() ([]SwComponent, error) {
 	return *v, nil
 }
 
-func (c P1Claims) GetNonce() ([]byte, error) {
+func (c P1Claims) GetNonce() ([]byte, error) { //nolint:gocritic
 	v := c.Nonce
 
 	if v == nil {
@@ -284,7 +284,7 @@ func (c P1Claims) GetNonce() ([]byte, error) {
 	return *v, nil
 }
 
-func (c P1Claims) GetInstID() ([]byte, error) {
+func (c P1Claims) GetInstID() ([]byte, error) { //nolint:gocritic
 	v := c.InstID
 
 	if v == nil {
@@ -298,16 +298,16 @@ func (c P1Claims) GetInstID() ([]byte, error) {
 	return *v, nil
 }
 
-func (c P1Claims) GetVSI() (string, error) {
+func (c P1Claims) GetVSI() (string, error) { //nolint:gocritic
 	return getVSI(c.VSI)
 }
 
-func (c P1Claims) GetConfig() ([]byte, error) {
+func (c P1Claims) GetConfig() ([]byte, error) { //nolint:gocritic
 
 	return nil, fmt.Errorf("invalid GetConfig invoked on p1 claims")
 }
 
-func (c P1Claims) GetHashAlgID() (string, error) {
+func (c P1Claims) GetHashAlgID() (string, error) { //nolint:gocritic
 
 	return "", fmt.Errorf("invalid GetHashAlgID invoked on p1 claims")
 }

--- a/claims_p2.go
+++ b/claims_p2.go
@@ -11,7 +11,7 @@ import (
 	"github.com/veraison/eat"
 )
 
-//	P2Claims are associated with profile "http://arm.com/psa/2.0.0"
+// P2Claims are associated with profile "http://arm.com/psa/2.0.0"
 type P2Claims struct {
 	Profile                *eat.Profile   `cbor:"265,keyasint" json:"eat-profile"`
 	ClientID               *int32         `cbor:"2394,keyasint" json:"psa-client-id"`
@@ -129,14 +129,23 @@ func (c *P2Claims) SetHashAlgID(v string) error {
 // Codecs
 
 func (c *P2Claims) FromCBOR(buf []byte) error {
-	err := dm.Unmarshal(buf, c)
+	err := c.FromUnvalidatedCBOR(buf)
 	if err != nil {
-		return fmt.Errorf("CBOR decoding of PSA claims failed: %w", err)
+		return err
 	}
 
 	err = c.Validate()
 	if err != nil {
 		return fmt.Errorf("validation of PSA claims failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *P2Claims) FromUnvalidatedCBOR(buf []byte) error {
+	err := dm.Unmarshal(buf, c)
+	if err != nil {
+		return fmt.Errorf("CBOR decoding of PSA claims failed: %w", err)
 	}
 
 	return nil
@@ -148,6 +157,10 @@ func (c P2Claims) ToCBOR() ([]byte, error) {
 		return nil, fmt.Errorf("validation of PSA claims failed: %w", err)
 	}
 
+	return c.ToUnvalidatedCBOR()
+}
+
+func (c P2Claims) ToUnvalidatedCBOR() ([]byte, error) {
 	buf, err := em.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("CBOR encoding of PSA claims failed: %w", err)
@@ -157,14 +170,23 @@ func (c P2Claims) ToCBOR() ([]byte, error) {
 }
 
 func (c *P2Claims) FromJSON(buf []byte) error {
-	err := json.Unmarshal(buf, c)
+	err := c.FromUnvalidatedJSON(buf)
 	if err != nil {
-		return fmt.Errorf("JSON decoding of PSA claims failed: %w", err)
+		return err
 	}
 
 	err = c.Validate()
 	if err != nil {
 		return fmt.Errorf("validation of PSA claims failed: %w", err)
+	}
+
+	return nil
+}
+
+func (c *P2Claims) FromUnvalidatedJSON(buf []byte) error {
+	err := json.Unmarshal(buf, c)
+	if err != nil {
+		return fmt.Errorf("JSON decoding of PSA claims failed: %w", err)
 	}
 
 	return nil
@@ -176,6 +198,10 @@ func (c P2Claims) ToJSON() ([]byte, error) {
 		return nil, fmt.Errorf("validation of PSA claims failed: %w", err)
 	}
 
+	return c.ToUnvalidatedJSON()
+}
+
+func (c P2Claims) ToUnvalidatedJSON() ([]byte, error) {
 	buf, err := json.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("JSON encoding of PSA claims failed: %w", err)

--- a/claims_p2.go
+++ b/claims_p2.go
@@ -36,7 +36,7 @@ func newP2Claims() (IClaims, error) {
 }
 
 // Semantic validation
-func (c P2Claims) Validate() error {
+func (c P2Claims) Validate() error { //nolint:gocritic
 	return validate(&c, PsaProfile2)
 }
 
@@ -151,7 +151,7 @@ func (c *P2Claims) FromUnvalidatedCBOR(buf []byte) error {
 	return nil
 }
 
-func (c P2Claims) ToCBOR() ([]byte, error) {
+func (c P2Claims) ToCBOR() ([]byte, error) { //nolint:gocritic
 	err := c.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("validation of PSA claims failed: %w", err)
@@ -160,7 +160,7 @@ func (c P2Claims) ToCBOR() ([]byte, error) {
 	return c.ToUnvalidatedCBOR()
 }
 
-func (c P2Claims) ToUnvalidatedCBOR() ([]byte, error) {
+func (c P2Claims) ToUnvalidatedCBOR() ([]byte, error) { //nolint:gocritic
 	buf, err := em.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("CBOR encoding of PSA claims failed: %w", err)
@@ -192,7 +192,7 @@ func (c *P2Claims) FromUnvalidatedJSON(buf []byte) error {
 	return nil
 }
 
-func (c P2Claims) ToJSON() ([]byte, error) {
+func (c P2Claims) ToJSON() ([]byte, error) { //nolint:gocritic
 	err := c.Validate()
 	if err != nil {
 		return nil, fmt.Errorf("validation of PSA claims failed: %w", err)
@@ -201,7 +201,7 @@ func (c P2Claims) ToJSON() ([]byte, error) {
 	return c.ToUnvalidatedJSON()
 }
 
-func (c P2Claims) ToUnvalidatedJSON() ([]byte, error) {
+func (c P2Claims) ToUnvalidatedJSON() ([]byte, error) { //nolint:gocritic
 	buf, err := json.Marshal(&c)
 	if err != nil {
 		return nil, fmt.Errorf("JSON encoding of PSA claims failed: %w", err)
@@ -215,7 +215,7 @@ func (c P2Claims) ToUnvalidatedJSON() ([]byte, error) {
 // to never fail.  Getters of optional claim may still fail with
 // ErrOptionalClaimMissing in case the claim is not present.
 
-func (c P2Claims) GetProfile() (string, error) {
+func (c P2Claims) GetProfile() (string, error) { //nolint:gocritic
 	if c.Profile == nil {
 		return "", ErrMandatoryClaimMissing
 	}
@@ -223,27 +223,27 @@ func (c P2Claims) GetProfile() (string, error) {
 	return c.Profile.Get()
 }
 
-func (c P2Claims) GetClientID() (int32, error) {
+func (c P2Claims) GetClientID() (int32, error) { //nolint:gocritic
 	return getClientID(c.ClientID)
 }
 
-func (c P2Claims) GetSecurityLifeCycle() (uint16, error) {
+func (c P2Claims) GetSecurityLifeCycle() (uint16, error) { //nolint:gocritic
 	return getSecurityLifeCycle(c.SecurityLifeCycle, PsaProfile2)
 }
 
-func (c P2Claims) GetImplID() ([]byte, error) {
+func (c P2Claims) GetImplID() ([]byte, error) { //nolint:gocritic
 	return getImplID(c.ImplID)
 }
 
-func (c P2Claims) GetBootSeed() ([]byte, error) {
+func (c P2Claims) GetBootSeed() ([]byte, error) { //nolint:gocritic
 	return getBootSeed(c.BootSeed, PsaProfile2)
 }
 
-func (c P2Claims) GetCertificationReference() (string, error) {
+func (c P2Claims) GetCertificationReference() (string, error) { //nolint:gocritic
 	return getCertificationReference(c.CertificationReference, PsaProfile2)
 }
 
-func (c P2Claims) GetSoftwareComponents() ([]SwComponent, error) {
+func (c P2Claims) GetSoftwareComponents() ([]SwComponent, error) { //nolint:gocritic
 	v := c.SwComponents
 
 	if v == nil {
@@ -257,7 +257,7 @@ func (c P2Claims) GetSoftwareComponents() ([]SwComponent, error) {
 	return *v, nil
 }
 
-func (c P2Claims) GetNonce() ([]byte, error) {
+func (c P2Claims) GetNonce() ([]byte, error) { //nolint:gocritic
 	v := c.Nonce
 
 	if v == nil {
@@ -278,7 +278,7 @@ func (c P2Claims) GetNonce() ([]byte, error) {
 	return n, nil
 }
 
-func (c P2Claims) GetInstID() ([]byte, error) {
+func (c P2Claims) GetInstID() ([]byte, error) { //nolint:gocritic
 	v := c.InstID
 
 	if v == nil {
@@ -292,14 +292,14 @@ func (c P2Claims) GetInstID() ([]byte, error) {
 	return *v, nil
 }
 
-func (c P2Claims) GetVSI() (string, error) {
+func (c P2Claims) GetVSI() (string, error) { //nolint:gocritic
 	return getVSI(c.VSI)
 }
 
-func (c P2Claims) GetConfig() ([]byte, error) {
+func (c P2Claims) GetConfig() ([]byte, error) { //nolint:gocritic
 	return nil, fmt.Errorf("invalid GetConfig invoked on p2 claims")
 }
 
-func (c P2Claims) GetHashAlgID() (string, error) {
+func (c P2Claims) GetHashAlgID() (string, error) { //nolint:gocritic
 	return "", fmt.Errorf("invalid GetHashAlgID invoked on p2 claims")
 }

--- a/doc.go
+++ b/doc.go
@@ -75,4 +75,5 @@ processed, e.g.:
 	myPolicy.VerifyAttestation(evidence.Claims)
 
 */
+//nolint:gofmt
 package psatoken

--- a/iclaims_test.go
+++ b/iclaims_test.go
@@ -41,7 +41,7 @@ func Test_DecodeClaims_p1_failure(t *testing.T) {
 		buf := mustHexDecode(t, tv)
 		_, err := DecodeClaims(buf)
 
-		expectedError := `decode failed for all CcaPlatform(validation of CCA platform claims failed: validating profile: missing mandatory claim), p1 (validation of PSA claims failed: validating psa-nonce: missing mandatory claim) and p2 (validation of PSA claims failed: validating profile: missing mandatory claim)`
+		expectedError := `decode failed for all CcaPlatform (validation of CCA platform claims failed: validating profile: missing mandatory claim), p1 (validation of PSA claims failed: validating psa-nonce: missing mandatory claim) and p2 (validation of PSA claims failed: validating profile: missing mandatory claim)`
 
 		assert.EqualError(t, err, expectedError)
 	}
@@ -75,7 +75,7 @@ func Test_DecodeClaims_p2_failure(t *testing.T) {
 		buf := mustHexDecode(t, tv)
 		_, err := DecodeClaims(buf)
 
-		expectedError := `decode failed for all CcaPlatform(validation of CCA platform claims failed: wrong profile: expecting "http://arm.com/CCA-SSD/1.0.0", got "http://arm.com/psa/2.0.0"), p1 (validation of PSA claims failed: validating psa-security-lifecycle: missing mandatory claim) and p2 (validation of PSA claims failed: validating psa-nonce: missing mandatory claim)`
+		expectedError := `decode failed for all CcaPlatform (validation of CCA platform claims failed: wrong profile: expecting "http://arm.com/CCA-SSD/1.0.0", got "http://arm.com/psa/2.0.0"), p1 (validation of PSA claims failed: validating psa-security-lifecycle: missing mandatory claim) and p2 (validation of PSA claims failed: validating psa-nonce: missing mandatory claim)`
 
 		assert.EqualError(t, err, expectedError)
 	}
@@ -108,9 +108,30 @@ func Test_DecodeClaims_CcaPlatform_failure(t *testing.T) {
 		buf := mustHexDecode(t, tv)
 		_, err := DecodeClaims(buf)
 
-		expectedError := `decode failed for all CcaPlatform(validation of CCA platform claims failed: validating psa-nonce: missing mandatory claim), p1 (validation of PSA claims failed: validating psa-security-lifecycle: missing mandatory claim) and p2 (validation of PSA claims failed: wrong profile: expecting "http://arm.com/psa/2.0.0", got "http://arm.com/CCA-SSD/1.0.0")`
+		expectedError := `decode failed for all CcaPlatform (validation of CCA platform claims failed: validating psa-nonce: missing mandatory claim), p1 (validation of PSA claims failed: validating psa-security-lifecycle: missing mandatory claim) and p2 (validation of PSA claims failed: wrong profile: expecting "http://arm.com/psa/2.0.0", got "http://arm.com/CCA-SSD/1.0.0")`
 
 		assert.EqualError(t, err, expectedError)
+	}
+}
+
+func Test_DecodeUnvalidatedClaims(t *testing.T) {
+	type TestVector struct {
+		Input    string
+		Expected interface{}
+	}
+
+	tvs := []TestVector{
+		{testEncodedP1ClaimsMissingMandatoryNonce, &P1Claims{}},
+		{testEncodedP2ClaimsMissingMandatoryNonce, &P2Claims{}},
+		{testEncodedCcaPlatformClaimsMissingMandatoryNonce, &CcaPlatformClaims{}},
+	}
+
+	for _, tv := range tvs {
+		buf := mustHexDecode(t, tv.Input)
+		v, err := DecodeUnvalidatedClaims(buf)
+
+		assert.NoError(t, err)
+		assert.IsType(t, tv.Expected, v)
 	}
 }
 
@@ -300,4 +321,37 @@ func Test_DecodeJSONClaims_CcaPlatform(t *testing.T) {
 	actualProfile, err := c.GetProfile()
 	assert.NoError(t, err)
 	assert.Equal(t, CcaProfile, actualProfile)
+}
+
+func Test_DecodeUnvalidatedJSONClaims(t *testing.T) {
+	type TestVector struct {
+		Path     string
+		Expected interface{}
+	}
+	tvs := []TestVector{
+		// valid
+		{"testvectors/json/test-token-valid-minimalist-p1.json", &P2Claims{}},
+		{"testvectors/json/test-token-valid-minimalist-p2.json", &P2Claims{}},
+		{"testvectors/json/ccatoken/test-token-valid-full.json", &CcaPlatformClaims{}},
+
+		// invalid
+		{"testvectors/json/test-boot-seed-invalid-long.json", &P2Claims{}},
+		{"testvectors/json/test-boot-seed-invalid-missing.json", &P2Claims{}},
+		{"testvectors/json/test-hardware-version-invalid.json", &P2Claims{}},
+		{"testvectors/json/test-sw-components-invalid-missing.json", &P2Claims{}},
+		{"testvectors/json/test-security-lifecycle-invalid-state.json", &P2Claims{}},
+		{"testvectors/json/ccatoken/test-no-sw-components.json", &CcaPlatformClaims{}},
+		{"testvectors/json/ccatoken/test-invalid-profile.json", &CcaPlatformClaims{}},
+		{"testvectors/json/ccatoken/test-invalid-psa-claims.json", &CcaPlatformClaims{}},
+	}
+
+	for _, tv := range tvs {
+		buf, err := os.ReadFile(tv.Path)
+		require.NoError(t, err)
+
+		v, err := DecodeUnvalidatedJSONClaims(buf)
+
+		assert.NoError(t, err)
+		assert.IsType(t, tv.Expected, v)
+	}
 }

--- a/testvectors/json/ccatoken/test-invalid-psa-claims.json
+++ b/testvectors/json/ccatoken/test-invalid-psa-claims.json
@@ -1,0 +1,29 @@
+{
+  "cca-platform-profile": "http://arm.com/PSA-SSD/1.0.0",
+  "cca-platform-challenge":  "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=",
+  "cca-platform-instance-id": "AQICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIC",
+  "psa-implementation-id": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
+  "psa-boot-seed": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIg==",
+  "cca-platform-config": "AQID",
+  "cca-platform-lifecycle": 12288,
+  "cca-platform-sw-components": [
+    {
+      "measurement-value": "AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=",
+      "signer-id": "BAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQ="
+    }
+  ],
+  "psa-software-components": [
+    {
+      "measurement-type": "BL",
+      "measurement-value": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
+      "signer-id": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA="
+    },
+    {
+      "measurement-type": "PRoT",
+      "measurement-value": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=",
+      "signer-id": "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA="
+    }
+  ],
+  "cca-platform-service-indicator" : "https://veraison.example/v1/challenge-response",
+  "cca-platform-hash-algo-id": "sha-256"
+}


### PR DESCRIPTION
Allow marshalling and unmarshalling of invalid tokens via a command line flag. This is useful for testing.