### PR TITLE
Add missing `MarshalJSON` interface to `Evidence`

### DIFF
--- a/evidence.go
+++ b/evidence.go
@@ -184,3 +184,8 @@ func (e *Evidence) doSign(signer cose.Signer) ([]byte, error) {
 
 	return wrap, nil
 }
+
+// MarshalJSON encodes the PSA claims-set to JSON
+func (e *Evidence) MarshalJSON() ([]byte, error) {
+	return EncodeClaimsToJSON(e.Claims)
+}

--- a/evidence_test.go
+++ b/evidence_test.go
@@ -313,7 +313,7 @@ func TestEvidence_sign_and_verify_alg_mismatch(t *testing.T) {
 	var pk crypto.PublicKey
 
 	err = EvidenceOut.Verify(pk)
-	assert.EqualError(t, err, "unable to instantiate verifier: ES256: algorithm mismatch")
+	assert.EqualError(t, err, "unable to instantiate verifier: ES256: invalid public key")
 }
 
 func TestEvidence_SignUnvalidated(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lestrrat-go/jwx/v2 v2.0.8
 	github.com/stretchr/testify v1.8.1
 	github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff
-	github.com/veraison/go-cose v1.0.0-rc.1
+	github.com/veraison/go-cose v1.3.0-rc.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,8 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff h1:r6I2eJL/z8dp5flsQIKHMeDjyV6UO8If3MaVBLvTjF4=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
-github.com/veraison/go-cose v1.0.0-rc.1 h1:4qA7dbFJGvt7gcqv5MCIyCQvN+NpHFPkW7do3EeDLb8=
-github.com/veraison/go-cose v1.0.0-rc.1/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
+github.com/veraison/go-cose v1.3.0-rc.1 h1:j7mMBdwkbq4c+pgEZVbbWG8UwVIgGHPp6+TAAYJj+UY=
+github.com/veraison/go-cose v1.3.0-rc.1/go.mod h1:df09OV91aHoQWLmy1KsDdYiagtXgyAwAl8vFeFn1gMc=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f h1:OeJjE6G4dgCY4PIXvIRQbE8+RX+uXZyGhUy/ksMGJoc=


### PR DESCRIPTION
It is offered by ccatoken and needed by (an updated version of) the ClaimMapper interface used by the service schemes.